### PR TITLE
Fixes domain mapping being recreated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,8 +166,7 @@ resource "google_cloud_run_service" "main" {
       metadata[0].annotations["run.googleapis.com/client-name"],
       metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["client.knative.dev/user-image"],
-      metadata[0].annotations["serving.knative.dev/creator"],
-      metadata[0].annotations["serving.knative.dev/lastModifier"],
+      metadata[0]["run.googleapis.com/operation-id"],
       traffic
     ]
   }
@@ -190,6 +189,14 @@ resource "google_cloud_run_domain_mapping" "domain_map" {
     route_name       = google_cloud_run_service.main.name
     force_override   = var.force_override
     certificate_mode = var.certificate_mode
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["serving.knative.dev/creator"],
+      metadata[0].annotations["serving.knative.dev/lastModifier"],
+      metadata[0].annotations["run.googleapis.com/operation-id"],
+    ]
   }
 }
 


### PR DESCRIPTION

## What this PR does

- [x] Fixes domain mapping getting recreated every apply after deploying outside of terraform thereby causing outages. Ignores metadata changes in domain mapping resource